### PR TITLE
Added .NET 4.8.1 as a build target and refactored to C#8 to accommodate

### DIFF
--- a/cs-serviceclient/cs-serviceclient/ServiceClient/Constants/UUIDs.cs
+++ b/cs-serviceclient/cs-serviceclient/ServiceClient/Constants/UUIDs.cs
@@ -1,92 +1,98 @@
-﻿namespace AMRC.FactoryPlus.ServiceClient.Constants;
+﻿using System;
+using System.Collections.Generic;
 
-public enum AppSubcomponents
+namespace AMRC.FactoryPlus.ServiceClient.Constants
 {
-    Registration,
-    Info,
-    SparkplugAddress
-}
 
-public enum ClassTypes
-{
-    Class,
-    Device,
-    Schema,
-    App,
-    Service
-}
-
-public enum SchemaTypes
-{
-    Device_Information,
-    Service
-}
-
-public enum ServiceTypes
-{
-    Directory,
-    ConfigDB,
-    Registry,
-    Authentication,
-    CommandEscalation,
-    MQTT
-}
-
-/// <summary>
-/// A helper class of Guids
-/// </summary>
-public static class UUIDs
-{
-    /// <summary>
-    /// The global FactoryPlus identifier
-    /// </summary>
-    const string FactoryPlus = "11ad7b32-1d32-4c4a-b0c9-fa049208939a";
-    /// <summary>
-    /// A Null Guid, likely deprecated. Use Guid.Empty
-    /// </summary>
-    const string Null = "00000000-0000-0000-0000-000000000000";
-
-    /// <summary>
-    /// App Guids
-    /// </summary>
-    public static Dictionary<AppSubcomponents, Guid> App = new() 
+    public enum AppSubcomponents
     {
-        {AppSubcomponents.Registration, new Guid("cb40bed5-49ad-4443-a7f5-08c75009da8f")},
-        {AppSubcomponents.Info, new Guid("64a8bfa9-7772-45c4-9d1a-9e6290690957")},
-        {AppSubcomponents.SparkplugAddress, new Guid("8e32801b-f35a-4cbf-a5c3-2af64d3debd7")},
-    };
+        Registration,
+        Info,
+        SparkplugAddress
+    }
+
+    public enum ClassTypes
+    {
+        Class,
+        Device,
+        Schema,
+        App,
+        Service
+    }
+
+    public enum SchemaTypes
+    {
+        Device_Information,
+        Service
+    }
+
+    public enum ServiceTypes
+    {
+        Directory,
+        ConfigDB,
+        Registry,
+        Authentication,
+        CommandEscalation,
+        MQTT
+    }
 
     /// <summary>
-    /// Class Guids
+    /// A helper class of Guids
     /// </summary>
-    public static Dictionary<ClassTypes, Guid> Class = new() 
+    public static class UUIDs
     {
-        {ClassTypes.Class, new Guid("04a1c90d-2295-4cbe-b33a-74eded62cbf1")},
-        {ClassTypes.Device, new Guid("18773d6d-a70d-443a-b29a-3f1583195290")},
-        {ClassTypes.Schema, new Guid("83ee28d4-023e-4c2c-ab86-12c24e86372c")},
-        {ClassTypes.App, new Guid("d319bd87-f42b-4b66-be4f-f82ff48b93f0")},
-        {ClassTypes.Service, new Guid("265d481f-87a7-4f93-8fc6-53fa64dc11bb")},
-    };
+        /// <summary>
+        /// The global FactoryPlus identifier
+        /// </summary>
+        const string FactoryPlus = "11ad7b32-1d32-4c4a-b0c9-fa049208939a";
 
-    /// <summary>
-    /// Schema Guids
-    /// </summary>
-    public static Dictionary<SchemaTypes, Guid> Schema = new() 
-    {
-        {SchemaTypes.Device_Information, new Guid("2dd093e9-1450-44c5-be8c-c0d78e48219b")},
-        {SchemaTypes.Service, new Guid("05688a03-730e-4cda-9932-172e2c62e45c")}
-    };
+        /// <summary>
+        /// A Null Guid, likely deprecated. Use Guid.Empty
+        /// </summary>
+        const string Null = "00000000-0000-0000-0000-000000000000";
 
-    /// <summary>
-    /// Service Guids
-    /// </summary>
-    public static Dictionary<ServiceTypes, Guid> Service = new() 
-    {
-        {ServiceTypes.Directory, new Guid("af4a1d66-e6f7-43c4-8a67-0fa3be2b1cf9")},
-        {ServiceTypes.ConfigDB, new Guid("af15f175-78a0-4e05-97c0-2a0bb82b9f3b")},
-        {ServiceTypes.Registry, new Guid("af15f175-78a0-4e05-97c0-2a0bb82b9f3b")},
-        {ServiceTypes.Authentication, new Guid("cab2642a-f7d9-42e5-8845-8f35affe1fd4")},
-        {ServiceTypes.CommandEscalation, new Guid("78ea7071-24ac-4916-8351-aa3e549d8ccd")},
-        {ServiceTypes.MQTT, new Guid("feb27ba3-bd2c-4916-9269-79a61ebc4a47")},
-    };
+        /// <summary>
+        /// App Guids
+        /// </summary>
+        public static Dictionary<AppSubcomponents, Guid> App = new Dictionary<AppSubcomponents, Guid>()
+        {
+            {AppSubcomponents.Registration, new Guid("cb40bed5-49ad-4443-a7f5-08c75009da8f")},
+            {AppSubcomponents.Info, new Guid("64a8bfa9-7772-45c4-9d1a-9e6290690957")},
+            {AppSubcomponents.SparkplugAddress, new Guid("8e32801b-f35a-4cbf-a5c3-2af64d3debd7")},
+        };
+
+        /// <summary>
+        /// Class Guids
+        /// </summary>
+        public static Dictionary<ClassTypes, Guid> Class = new Dictionary<ClassTypes, Guid>()
+        {
+            {ClassTypes.Class, new Guid("04a1c90d-2295-4cbe-b33a-74eded62cbf1")},
+            {ClassTypes.Device, new Guid("18773d6d-a70d-443a-b29a-3f1583195290")},
+            {ClassTypes.Schema, new Guid("83ee28d4-023e-4c2c-ab86-12c24e86372c")},
+            {ClassTypes.App, new Guid("d319bd87-f42b-4b66-be4f-f82ff48b93f0")},
+            {ClassTypes.Service, new Guid("265d481f-87a7-4f93-8fc6-53fa64dc11bb")},
+        };
+
+        /// <summary>
+        /// Schema Guids
+        /// </summary>
+        public static Dictionary<SchemaTypes, Guid> Schema = new Dictionary<SchemaTypes, Guid>()
+        {
+            {SchemaTypes.Device_Information, new Guid("2dd093e9-1450-44c5-be8c-c0d78e48219b")},
+            {SchemaTypes.Service, new Guid("05688a03-730e-4cda-9932-172e2c62e45c")}
+        };
+
+        /// <summary>
+        /// Service Guids
+        /// </summary>
+        public static Dictionary<ServiceTypes, Guid> Service = new Dictionary<ServiceTypes, Guid>()
+        {
+            {ServiceTypes.Directory, new Guid("af4a1d66-e6f7-43c4-8a67-0fa3be2b1cf9")},
+            {ServiceTypes.ConfigDB, new Guid("af15f175-78a0-4e05-97c0-2a0bb82b9f3b")},
+            {ServiceTypes.Registry, new Guid("af15f175-78a0-4e05-97c0-2a0bb82b9f3b")},
+            {ServiceTypes.Authentication, new Guid("cab2642a-f7d9-42e5-8845-8f35affe1fd4")},
+            {ServiceTypes.CommandEscalation, new Guid("78ea7071-24ac-4916-8351-aa3e549d8ccd")},
+            {ServiceTypes.MQTT, new Guid("feb27ba3-bd2c-4916-9269-79a61ebc4a47")},
+        };
+    }
 }

--- a/cs-serviceclient/cs-serviceclient/ServiceClient/ServiceClient.cs
+++ b/cs-serviceclient/cs-serviceclient/ServiceClient/ServiceClient.cs
@@ -2,142 +2,156 @@
 using AMRC.FactoryPlus.ServiceClient.Services;
 using Directory = AMRC.FactoryPlus.ServiceClient.Services.Directory;
 
-namespace AMRC.FactoryPlus.ServiceClient;
-
-/// <summary>
-/// The ServiceClient holds interfaces with individual F+ services
-/// </summary>
-public class ServiceClient
+namespace AMRC.FactoryPlus.ServiceClient
 {
-    /// <summary>
-    /// The Auth interface
-    /// </summary>
-    public readonly Auth Auth;
-    /// <summary>
-    /// The ConfigDB interface
-    /// </summary>
-    public readonly ConfigDb ConfigDb;
-    /// <summary>
-    /// The Directory interface
-    /// </summary>
-    public readonly Directory Directory;
-    /// <summary>
-    /// The Discover interface
-    /// </summary>
-    public readonly Discovery Discovery;
-    /// <summary>
-    /// The Fetch interface
-    /// </summary>
-    public readonly FetchClass Fetch;
-    /// <summary>
-    /// The MQTT interface
-    /// </summary>
-    public readonly MqttInterface Mqtt;
 
     /// <summary>
-    /// The username to use for Basic auth with services
+    /// The ServiceClient holds interfaces with individual F+ services
     /// </summary>
-    public string? ServiceUsername;
-    /// <summary>
-    /// The password to use for Basic auth with services
-    /// </summary>
-    public string? ServicePassword;
-    /// <summary>
-    /// The root principal to authenticate
-    /// </summary>
-    public string? RootPrincipal;
-    /// <summary>
-    /// The permission group to authenticate
-    /// </summary>
-    public string? PermissionGroup;
-    /// <summary>
-    /// The URL of the Authenticate service
-    /// </summary>
-    public string? AuthnUrl;
-    /// <summary>
-    /// The URL of the ConfigDB service
-    /// </summary>
-    public string? ConfigDbUrl;
-    /// <summary>
-    /// The URL of the Directory service
-    /// </summary>
-    public string? DirectoryUrl;
-    /// <summary>
-    /// The URL of the MQTT service
-    /// </summary>
-    public string? MqttUrl;
-
-    /// <summary>
-    /// Creates a ServiceClient that allows for interaction with F+ services.
-    /// Provides all the config details at once.
-    /// </summary>
-    /// <param name="serviceUsername">The username to use for Basic auth with services</param>
-    /// <param name="servicePassword">The password to use for Basic auth with services</param>
-    /// <param name="rootPrincipal">The root principal to authenticate</param>
-    /// <param name="permissionGroup">The permission group to authenticate</param>
-    /// <param name="authnUrl">The URL of the Authenticate service</param>
-    /// <param name="configDbUrl">The URL of the ConfigDB service</param>
-    /// <param name="directoryUrl">The URL of the Directory service</param>
-    /// <param name="mqttUrl">The URL of the MQTT service</param>
-    public ServiceClient(string? serviceUsername, string? servicePassword, string? rootPrincipal,
-                         string? permissionGroup, string? authnUrl, string? configDbUrl, string? directoryUrl, 
-                         string? mqttUrl)
+    public class ServiceClient
     {
-        ServiceUsername = serviceUsername;
-        ServicePassword = servicePassword;
-        RootPrincipal = rootPrincipal;
-        PermissionGroup = permissionGroup;
-        AuthnUrl = authnUrl;
-        ConfigDbUrl = configDbUrl;
-        DirectoryUrl = directoryUrl;
-        MqttUrl = mqttUrl;
-        
-        Auth = new Auth(this);
-        ConfigDb = new ConfigDb(this);
-        Directory = new Directory(this);
-        Discovery = new Discovery(this);
-        Fetch = new FetchClass(this);
-        Mqtt = new MqttInterface(this);
-    }
+        /// <summary>
+        /// The Auth interface
+        /// </summary>
+        public readonly Auth Auth;
 
-    /// <summary>
-    /// Creates a ServiceClient that allows for interaction with F+ services.
-    /// Provides only the minimum requirements to use Basic auth and get all URLs from the F+ Directory
-    /// </summary>
-    /// <param name="serviceUsername">The username to use for Basic auth with services</param>
-    /// <param name="servicePassword">The password to use for Basic auth with services</param>
-    /// <param name="directoryUrl">The URL of the Directory service</param>
-    public ServiceClient(string? serviceUsername, string? servicePassword, string? directoryUrl)
-        : this(serviceUsername, servicePassword, null, null, null, null,
-            directoryUrl, null) { }
+        /// <summary>
+        /// The ConfigDB interface
+        /// </summary>
+        public readonly ConfigDb ConfigDb;
 
-    /// <summary>
-    /// Updates the settings that are used for the services
-    /// </summary>
-    /// <param name="serviceUsername">The username to use for Basic auth with services</param>
-    /// <param name="servicePassword">The password to use for Basic auth with services</param>
-    /// <param name="rootPrincipal">The root principal to authenticate</param>
-    /// <param name="permissionGroup">The permission group to authenticate</param>
-    /// <param name="authnUrl">The URL of the Authenticate service</param>
-    /// <param name="configDbUrl">The URL of the ConfigDB service</param>
-    /// <param name="directoryUrl">The URL of the Directory service</param>
-    /// <param name="mqttUrl">The URL of the MQTT service</param>
-    public void UpdateConfig(string? serviceUsername, string? servicePassword, string? rootPrincipal,
-                             string? permissionGroup, string? authnUrl, string? configDbUrl, string? directoryUrl, 
+        /// <summary>
+        /// The Directory interface
+        /// </summary>
+        public readonly Directory Directory;
+
+        /// <summary>
+        /// The Discover interface
+        /// </summary>
+        public readonly Discovery Discovery;
+
+        /// <summary>
+        /// The Fetch interface
+        /// </summary>
+        public readonly FetchClass Fetch;
+
+        /// <summary>
+        /// The MQTT interface
+        /// </summary>
+        public readonly MqttInterface Mqtt;
+
+        /// <summary>
+        /// The username to use for Basic auth with services
+        /// </summary>
+        public string? ServiceUsername;
+
+        /// <summary>
+        /// The password to use for Basic auth with services
+        /// </summary>
+        public string? ServicePassword;
+
+        /// <summary>
+        /// The root principal to authenticate
+        /// </summary>
+        public string? RootPrincipal;
+
+        /// <summary>
+        /// The permission group to authenticate
+        /// </summary>
+        public string? PermissionGroup;
+
+        /// <summary>
+        /// The URL of the Authenticate service
+        /// </summary>
+        public string? AuthnUrl;
+
+        /// <summary>
+        /// The URL of the ConfigDB service
+        /// </summary>
+        public string? ConfigDbUrl;
+
+        /// <summary>
+        /// The URL of the Directory service
+        /// </summary>
+        public string? DirectoryUrl;
+
+        /// <summary>
+        /// The URL of the MQTT service
+        /// </summary>
+        public string? MqttUrl;
+
+        /// <summary>
+        /// Creates a ServiceClient that allows for interaction with F+ services.
+        /// Provides all the config details at once.
+        /// </summary>
+        /// <param name="serviceUsername">The username to use for Basic auth with services</param>
+        /// <param name="servicePassword">The password to use for Basic auth with services</param>
+        /// <param name="rootPrincipal">The root principal to authenticate</param>
+        /// <param name="permissionGroup">The permission group to authenticate</param>
+        /// <param name="authnUrl">The URL of the Authenticate service</param>
+        /// <param name="configDbUrl">The URL of the ConfigDB service</param>
+        /// <param name="directoryUrl">The URL of the Directory service</param>
+        /// <param name="mqttUrl">The URL of the MQTT service</param>
+        public ServiceClient(string? serviceUsername, string? servicePassword, string? rootPrincipal,
+                             string? permissionGroup, string? authnUrl, string? configDbUrl, string? directoryUrl,
                              string? mqttUrl)
-    {
-        ServiceUsername = serviceUsername;
-        ServicePassword = servicePassword;
-        RootPrincipal = rootPrincipal;
-        PermissionGroup = permissionGroup;
-        AuthnUrl = authnUrl;
-        ConfigDbUrl = configDbUrl;
-        DirectoryUrl = directoryUrl;
-        MqttUrl = mqttUrl;
+        {
+            ServiceUsername = serviceUsername;
+            ServicePassword = servicePassword;
+            RootPrincipal = rootPrincipal;
+            PermissionGroup = permissionGroup;
+            AuthnUrl = authnUrl;
+            ConfigDbUrl = configDbUrl;
+            DirectoryUrl = directoryUrl;
+            MqttUrl = mqttUrl;
 
-        Discovery.SetServiceUrl(UUIDs.Service[ServiceTypes.Authentication], AuthnUrl);
-        Discovery.SetServiceUrl(UUIDs.Service[ServiceTypes.ConfigDB], ConfigDbUrl);
-        Discovery.SetServiceUrl(UUIDs.Service[ServiceTypes.Directory], DirectoryUrl);
-        Discovery.SetServiceUrl(UUIDs.Service[ServiceTypes.MQTT], MqttUrl);
+            Auth = new Auth(this);
+            ConfigDb = new ConfigDb(this);
+            Directory = new Directory(this);
+            Discovery = new Discovery(this);
+            Fetch = new FetchClass(this);
+            Mqtt = new MqttInterface(this);
+        }
+
+        /// <summary>
+        /// Creates a ServiceClient that allows for interaction with F+ services.
+        /// Provides only the minimum requirements to use Basic auth and get all URLs from the F+ Directory
+        /// </summary>
+        /// <param name="serviceUsername">The username to use for Basic auth with services</param>
+        /// <param name="servicePassword">The password to use for Basic auth with services</param>
+        /// <param name="directoryUrl">The URL of the Directory service</param>
+        public ServiceClient(string? serviceUsername, string? servicePassword, string? directoryUrl)
+            : this(serviceUsername, servicePassword, null, null, null, null,
+                directoryUrl, null) { }
+
+        /// <summary>
+        /// Updates the settings that are used for the services
+        /// </summary>
+        /// <param name="serviceUsername">The username to use for Basic auth with services</param>
+        /// <param name="servicePassword">The password to use for Basic auth with services</param>
+        /// <param name="rootPrincipal">The root principal to authenticate</param>
+        /// <param name="permissionGroup">The permission group to authenticate</param>
+        /// <param name="authnUrl">The URL of the Authenticate service</param>
+        /// <param name="configDbUrl">The URL of the ConfigDB service</param>
+        /// <param name="directoryUrl">The URL of the Directory service</param>
+        /// <param name="mqttUrl">The URL of the MQTT service</param>
+        public void UpdateConfig(string? serviceUsername, string? servicePassword, string? rootPrincipal,
+                                 string? permissionGroup, string? authnUrl, string? configDbUrl, string? directoryUrl,
+                                 string? mqttUrl)
+        {
+            ServiceUsername = serviceUsername;
+            ServicePassword = servicePassword;
+            RootPrincipal = rootPrincipal;
+            PermissionGroup = permissionGroup;
+            AuthnUrl = authnUrl;
+            ConfigDbUrl = configDbUrl;
+            DirectoryUrl = directoryUrl;
+            MqttUrl = mqttUrl;
+
+            Discovery.SetServiceUrl(UUIDs.Service[ServiceTypes.Authentication], AuthnUrl);
+            Discovery.SetServiceUrl(UUIDs.Service[ServiceTypes.ConfigDB], ConfigDbUrl);
+            Discovery.SetServiceUrl(UUIDs.Service[ServiceTypes.Directory], DirectoryUrl);
+            Discovery.SetServiceUrl(UUIDs.Service[ServiceTypes.MQTT], MqttUrl);
+        }
     }
 }

--- a/cs-serviceclient/cs-serviceclient/ServiceClient/Services/Auth.cs
+++ b/cs-serviceclient/cs-serviceclient/ServiceClient/Services/Auth.cs
@@ -1,331 +1,338 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Runtime.Serialization;
 using AMRC.FactoryPlus.ServiceClient.Constants;
 using Cysharp.Threading.Tasks;
 using Newtonsoft.Json;
 using Semver;
 
-namespace AMRC.FactoryPlus.ServiceClient.Services;
-
-public struct PostAceBody
+namespace AMRC.FactoryPlus.ServiceClient.Services
 {
-    public readonly Guid Permission;
-    public readonly Guid Target;
-    public readonly AceAction Action;
-    public readonly Guid Principal;
-    public readonly string Kerberos;
 
-    public PostAceBody(Guid permission, Guid target, AceAction action, Guid? principal = null, string kerberos = "")
+    public struct PostAceBody
     {
-        Permission = permission;
-        Target = target;
-        Action = action;
-        Principal = principal ?? Guid.Empty;
-        Kerberos = kerberos;
-    }
-}
+        public readonly Guid Permission;
+        public readonly Guid Target;
+        public readonly AceAction Action;
+        public readonly Guid Principal;
+        public readonly string Kerberos;
 
-public struct Address
-{
-    public string Group;
-    public string Node;
-
-    public Address(string group, string node)
-    {
-        Group = group;
-        Node = node;
-    }
-}
-
-public struct PrincipalMapping
-{
-    public Guid Uuid;
-    public string Kerberos;
-    public Address? Sparkplug;
-
-    public PrincipalMapping(Guid uuid, string kerberos, Address? sparkplugAddress)
-    {
-        Uuid = uuid;
-        Kerberos = kerberos;
-        Sparkplug = sparkplugAddress;
-    }
-}
-
-public struct FetchAclQuery
-{
-    public readonly string Principal;
-    public readonly string Permission;
-    [JsonProperty("by-uuid")]
-    public readonly bool ByUuid;
-
-    public FetchAclQuery(string principal, string permission, bool byUuid)
-    {
-        Principal = principal;
-        Permission = permission;
-        ByUuid = byUuid;
-    }
-}
-
-public struct Ace
-{
-    public Guid Permission;
-    public Guid Target;
-    public Guid Principal;
-    public string Kerberos;
-
-    public Ace(Guid permission, Guid target, Guid? principal = null, string kerberos = "")
-    {
-        Permission = permission;
-        Target = target;
-        Principal = principal ?? Guid.Empty;
-        Kerberos = kerberos;
-    }
-}
-
-public struct Acl
-{
-    [JsonProperty("acl")]
-    public List<Ace> AclList;
-
-    public Acl(List<Ace> aclList) => AclList = aclList;
-}
-
-public enum AceAction
-{
-    [EnumMember(Value = "add")] 
-    Add,
-    [EnumMember(Value = "delete")] 
-    Delete
-}
-
-/// <summary>
-/// The Auth service interface
-/// </summary>
-public class Auth : ServiceInterface
-{
-    /// <inheritdoc />
-    public Auth(ServiceClient serviceClient) : base(serviceClient)
-    {
-        ServiceType = ServiceTypes.Authentication;
-    }
-
-    public async UniTask<bool> CheckAcl(string? kerberos, Guid? uuid, string permission, string target, bool wild)
-    {
-        var aclList = await FetchAcl(kerberos, uuid, ServiceClient.PermissionGroup ?? "");
-        return aclList(permission, target, wild);
-    }
-
-    public async UniTask<Func<string, string, bool, bool>> FetchAcl(string? kerberos, Guid? uuid, string permissionGroup)
-    {
-        var type = "kerberos";
-        string principal = "";
-        if (!string.IsNullOrEmpty(kerberos))
+        public PostAceBody(Guid permission, Guid target, AceAction action, Guid? principal = null, string kerberos = "")
         {
-            principal = kerberos;
+            Permission = permission;
+            Target = target;
+            Action = action;
+            Principal = principal ?? Guid.Empty;
+            Kerberos = kerberos;
         }
-        else if (uuid != null && uuid != Guid.Empty)
+    }
+
+    public struct Address
+    {
+        public string Group;
+        public string Node;
+
+        public Address(string group, string node)
         {
-            type = "uuid";
-            principal = uuid.ToString() ?? "";
+            Group = group;
+            Node = node;
         }
-        else
+    }
+
+    public struct PrincipalMapping
+    {
+        public Guid Uuid;
+        public string Kerberos;
+        public Address? Sparkplug;
+
+        public PrincipalMapping(Guid uuid, string kerberos, Address? sparkplugAddress)
         {
-            type = "";
+            Uuid = uuid;
+            Kerberos = kerberos;
+            Sparkplug = sparkplugAddress;
+        }
+    }
+
+    public struct FetchAclQuery
+    {
+        public readonly string Principal;
+        public readonly string Permission;
+        [JsonProperty("by-uuid")] public readonly bool ByUuid;
+
+        public FetchAclQuery(string principal, string permission, bool byUuid)
+        {
+            Principal = principal;
+            Permission = permission;
+            ByUuid = byUuid;
+        }
+    }
+
+    public struct Ace
+    {
+        public Guid Permission;
+        public Guid Target;
+        public Guid Principal;
+        public string Kerberos;
+
+        public Ace(Guid permission, Guid target, Guid? principal = null, string kerberos = "")
+        {
+            Permission = permission;
+            Target = target;
+            Principal = principal ?? Guid.Empty;
+            Kerberos = kerberos;
+        }
+    }
+
+    public struct Acl
+    {
+        [JsonProperty("acl")] public List<Ace> AclList;
+
+        public Acl(List<Ace> aclList) => AclList = aclList;
+    }
+
+    public enum AceAction
+    {
+        [EnumMember(Value = "add")] Add,
+        [EnumMember(Value = "delete")] Delete
+    }
+
+    /// <summary>
+    /// The Auth service interface
+    /// </summary>
+    public class Auth : ServiceInterface
+    {
+        /// <inheritdoc />
+        public Auth(ServiceClient serviceClient) : base(serviceClient)
+        {
+            ServiceType = ServiceTypes.Authentication;
         }
 
-        if (String.IsNullOrEmpty(type))
+        public async UniTask<bool> CheckAcl(string? kerberos, Guid? uuid, string permission, string target, bool wild)
         {
-            Debug.WriteLine($"Unrecognised principal request: {kerberos}, {uuid}");
-            return (s1, s2, b1) => false;
+            var aclList = await FetchAcl(kerberos, uuid, ServiceClient.PermissionGroup ?? "");
+            return aclList(permission, target, wild);
         }
 
-        if (!String.IsNullOrEmpty(ServiceClient.RootPrincipal)
-         && type == "kerberos"
-         && principal == ServiceClient.RootPrincipal)
+        public async UniTask<Func<string, string, bool, bool>> FetchAcl(string? kerberos, Guid? uuid,
+                                                                        string permissionGroup)
         {
-            return (s1, s2, b1) => true;
+            var type = "kerberos";
+            string principal = "";
+            if (!string.IsNullOrEmpty(kerberos))
+            {
+                principal = kerberos;
+            }
+            else if (uuid != null && uuid != Guid.Empty)
+            {
+                type = "uuid";
+                principal = uuid.ToString() ?? "";
+            }
+            else
+            {
+                type = "";
+            }
+
+            if (String.IsNullOrEmpty(type))
+            {
+                Debug.WriteLine($"Unrecognised principal request: {kerberos}, {uuid}");
+                return (s1, s2, b1) => false;
+            }
+
+            if (!String.IsNullOrEmpty(ServiceClient.RootPrincipal)
+             && type == "kerberos"
+             && principal == ServiceClient.RootPrincipal)
+            {
+                return (s1, s2, b1) => true;
+            }
+
+            var isUuid = type == "uuid";
+
+            var res = await ServiceClient.Fetch.Fetch(
+                "/authz/acl",
+                "GET",
+                new FetchAclQuery(principal, permissionGroup, isUuid),
+                UUIDs.Service[ServiceTypes.Authentication]);
+
+            if (res.Status != 200)
+            {
+                Debug.WriteLine($"{res.Status}: Failed to read ACL for {principal}");
+                return (s1, s2, b1) => false;
+            }
+
+            var acl = JsonConvert.DeserializeObject<Acl>(res.Content);
+
+            return (permission, target, wild) =>
+                acl.AclList.Any(ace =>
+                    ace.Permission == new Guid(permission)
+                 && (ace.Target == new Guid(target)
+                  || (wild && ace.Target == Guid.Empty))
+                );
         }
 
-        var isUuid = type == "uuid";
-
-        var res = await ServiceClient.Fetch.Fetch(
-            "/authz/acl",
-            "GET",
-            new FetchAclQuery(principal, permissionGroup, isUuid),
-            UUIDs.Service[ServiceTypes.Authentication]);
-
-        if (res.Status != 200)
+        public async UniTask<Guid> ResolvePrincipal(string query)
         {
-            Debug.WriteLine($"{res.Status}: Failed to read ACL for {principal}");
-            return (s1, s2, b1) => false;
-        }
-
-        var acl = JsonConvert.DeserializeObject<Acl>(res.Content);
-
-        return (permission, target, wild) =>
-            acl.AclList.Any(ace =>
-                ace.Permission == new Guid(permission)
-                && (ace.Target == new Guid(target)
-                || (wild && ace.Target == Guid.Empty))
-            );
-    }
-
-    public async UniTask<Guid> ResolvePrincipal(string query)
-    {
-        var res = await ServiceClient.Fetch.Fetch(
-            "/authz/principal/find",
-            "GET", 
-            query, 
-            UUIDs.Service[ServiceTypes.Authentication]
+            var res = await ServiceClient.Fetch.Fetch(
+                "/authz/principal/find",
+                "GET",
+                query,
+                UUIDs.Service[ServiceTypes.Authentication]
             );
 
-        if (res.Status != 200)
-        {
-            Debug.WriteLine($"{res.Status}: Failed to resolve {query}");
-            return Guid.Empty;
+            if (res.Status != 200)
+            {
+                Debug.WriteLine($"{res.Status}: Failed to resolve {query}");
+                return Guid.Empty;
+            }
+
+            var uuid = new Guid(res.Content);
+            Debug.WriteLine($"{res.Status}: Resolved {query} to {uuid}");
+            return uuid;
         }
 
-        var uuid = new Guid(res.Content);
-        Debug.WriteLine($"{res.Status}: Resolved {query} to {uuid}");
-        return uuid;
-    }
-
-    public async UniTask<PrincipalMapping?> FindPrincipal(Guid? guid = null, string? kerberos = null, Address? address = null)
-    {
-        var uuid = guid != null && guid != Guid.Empty ? guid
-            : !String.IsNullOrEmpty(kerberos) ? await ResolvePrincipal($"{{kerberos: {kerberos}}}")
-            : address != null ? (await ResolvePrincipalByAddress((Address)address))[0]
-            : await ResolvePrincipal("");
-
-        if (uuid == Guid.Empty)
+        public async UniTask<PrincipalMapping?> FindPrincipal(Guid? guid = null, string? kerberos = null,
+                                                              Address? address = null)
         {
-            return null;
+            var uuid = guid != null && guid != Guid.Empty ? guid
+                : !String.IsNullOrEmpty(kerberos) ? await ResolvePrincipal($"{{kerberos: {kerberos}}}")
+                : address != null ? (await ResolvePrincipalByAddress((Address) address))[0]
+                : await ResolvePrincipal("");
+
+            if (uuid == Guid.Empty)
+            {
+                return null;
+            }
+
+            var res = await Fetch($"/authz/principal/{uuid}");
+
+            if (res.Status != 200)
+            {
+                Debug.WriteLine($"{res.Status}: Failed to fetch principal {uuid}");
+                return null;
+            }
+
+            var ids = JsonConvert.DeserializeObject<PrincipalMapping>(res.Content);
+
+            var spConfig =
+                await ServiceClient.ConfigDb.GetConfig(UUIDs.App[AppSubcomponents.SparkplugAddress], (Guid) uuid);
+            if (spConfig != null)
+            {
+                ids.Sparkplug = new Address(spConfig.Value.GroupId, spConfig.Value.NodeId);
+            }
+
+            return ids;
         }
 
-        var res = await Fetch($"/authz/principal/{uuid}");
-
-        if (res.Status != 200)
+        public async UniTask AddPrincipal(Guid uuid, string kerberos)
         {
-            Debug.WriteLine($"{res.Status}: Failed to fetch principal {uuid}");
-            return null;
-        }
-
-        var ids = JsonConvert.DeserializeObject<PrincipalMapping>(res.Content);
-        
-        var spConfig = await ServiceClient.ConfigDb.GetConfig(UUIDs.App[AppSubcomponents.SparkplugAddress], (Guid)uuid);
-        if (spConfig != null)
-        {
-            ids.Sparkplug = new Address(spConfig.Value.GroupId, spConfig.Value.NodeId);
-        }
-        
-        return ids;
-    }
-
-    public async UniTask AddPrincipal(Guid uuid, string kerberos)
-    {
-        var res = await Fetch(
-            "authz/principal", 
-            "POST", 
-            null, 
-            null,
-            JsonConvert.SerializeObject(new PrincipalMapping(uuid, kerberos, null))
+            var res = await Fetch(
+                "authz/principal",
+                "POST",
+                null,
+                null,
+                JsonConvert.SerializeObject(new PrincipalMapping(uuid, kerberos, null))
             );
 
-        if (res.Status != 204)
-        {
-            throw new Exception($"{res.Status}: Can't create principal {kerberos}");
-        }
-    }
-
-    public async UniTask<Guid> CreatePrincipal(Guid klass, string kerberos, string name)
-    {
-        var cdb = ServiceClient.ConfigDb;
-        var uuid = await cdb.CreateObject(klass);
-
-        try
-        {
-            await AddPrincipal(uuid, kerberos);
-        }
-        catch (Exception)
-        {
-            await cdb.PutConfig(UUIDs.App[AppSubcomponents.Info], uuid, JsonConvert.SerializeObject(new PutConfigBody(name, true)));
-            throw;
+            if (res.Status != 204)
+            {
+                throw new Exception($"{res.Status}: Can't create principal {kerberos}");
+            }
         }
 
-        if (!String.IsNullOrEmpty(name))
+        public async UniTask<Guid> CreatePrincipal(Guid klass, string kerberos, string name)
         {
-            await cdb.PutConfig(UUIDs.App[AppSubcomponents.Info], uuid,
-                JsonConvert.SerializeObject(new PutConfigBody(name)));
+            var cdb = ServiceClient.ConfigDb;
+            var uuid = await cdb.CreateObject(klass);
+
+            try
+            {
+                await AddPrincipal(uuid, kerberos);
+            }
+            catch (Exception)
+            {
+                await cdb.PutConfig(UUIDs.App[AppSubcomponents.Info], uuid,
+                    JsonConvert.SerializeObject(new PutConfigBody(name, true)));
+                throw;
+            }
+
+            if (!String.IsNullOrEmpty(name))
+            {
+                await cdb.PutConfig(UUIDs.App[AppSubcomponents.Info], uuid,
+                    JsonConvert.SerializeObject(new PutConfigBody(name)));
+            }
+
+            return uuid;
         }
 
-        return uuid;
-    }
-
-    public async UniTask AddAce(Guid principal, Guid permission, Guid target)
-    {
-        await EditAce(new PostAceBody(permission, target, AceAction.Add, principal));
-    }
-
-    public async UniTask DeleteAce(Guid principal, Guid permission, Guid target)
-    {
-        await EditAce(new PostAceBody(permission, target, AceAction.Delete, principal));
-    }
-
-    public async UniTask AddToGroup(Guid group, Guid member)
-    {
-        var res = await Fetch($"authz/group/{group}/{member}", "PUT");
-        
-        if (res.Status != 204)
+        public async UniTask AddAce(Guid principal, Guid permission, Guid target)
         {
-            throw new Exception($"{res.Status}: Can't add {member} to group {group}");
-        }
-    }
-
-    public async UniTask RemoveFromGroup(Guid group, Guid member)
-    {
-        var res = await Fetch($"authz/group/{group}/{member}", "DELETE");
-        
-        if (res.Status != 204)
-        {
-            throw new Exception($"{res.Status}: Can't remove {member} from group {group}");
-        }
-    }
-
-    private async UniTask<Guid[]> ResolvePrincipalByAddress(Address address)
-    {
-        var cdb = ServiceClient.ConfigDb;
-        var ping = await cdb.Ping();
-        if (String.IsNullOrEmpty(ping?.Version) || !SemVersion.Parse(ping.Value.Version, SemVersionStyles.Strict).Satisfies(">=1.7 || =1.7.0-bmz"))
-        {
-            Debug.WriteLine($"ConfigDB is too old to search for addresses ({ping?.Version})");
-            return new[] { Guid.Empty };
+            await EditAce(new PostAceBody(permission, target, AceAction.Add, principal));
         }
 
-        var searchQuery = new Dictionary<string, object>
+        public async UniTask DeleteAce(Guid principal, Guid permission, Guid target)
+        {
+            await EditAce(new PostAceBody(permission, target, AceAction.Delete, principal));
+        }
+
+        public async UniTask AddToGroup(Guid group, Guid member)
+        {
+            var res = await Fetch($"authz/group/{group}/{member}", "PUT");
+
+            if (res.Status != 204)
+            {
+                throw new Exception($"{res.Status}: Can't add {member} to group {group}");
+            }
+        }
+
+        public async UniTask RemoveFromGroup(Guid group, Guid member)
+        {
+            var res = await Fetch($"authz/group/{group}/{member}", "DELETE");
+
+            if (res.Status != 204)
+            {
+                throw new Exception($"{res.Status}: Can't remove {member} from group {group}");
+            }
+        }
+
+        private async UniTask<Guid[]> ResolvePrincipalByAddress(Address address)
+        {
+            var cdb = ServiceClient.ConfigDb;
+            var ping = await cdb.Ping();
+            if (String.IsNullOrEmpty(ping?.Version) || !SemVersion.Parse(ping.Value.Version, SemVersionStyles.Strict)
+                                                                  .Satisfies(">=1.7 || =1.7.0-bmz"))
+            {
+                Debug.WriteLine($"ConfigDB is too old to search for addresses ({ping?.Version})");
+                return new[] {Guid.Empty};
+            }
+
+            var searchQuery = new Dictionary<string, object>
             {
                 ["group_id"] = address.Group, ["node_id"] = address.Node, ["device_id"] = ""
             };
-        var uuids = await cdb.Search(UUIDs.App[AppSubcomponents.SparkplugAddress], searchQuery, new Dictionary<string, string>());
-        if (uuids is {Length: 1})
-        {
-            return uuids;
+            var uuids = await cdb.Search(UUIDs.App[AppSubcomponents.SparkplugAddress], searchQuery,
+                new Dictionary<string, string>());
+            if (uuids is {Length: 1})
+            {
+                return uuids;
+            }
+
+            if (uuids != null && uuids.Length > 1)
+            {
+                Debug.WriteLine($"Multiple results resolving Sparkplug address {address}");
+            }
+
+            return new[] {Guid.Empty};
         }
 
-        if (uuids is {Length: > 1})
+        private async UniTask EditAce(PostAceBody spec)
         {
-            Debug.WriteLine($"Multiple results resolving Sparkplug address {address}");
-        }
-        
-        return new[] { Guid.Empty };
-    }
+            var res = await Fetch("authz/ace", "POST", null, null, JsonConvert.SerializeObject(spec));
 
-    private async UniTask EditAce(PostAceBody spec)
-    {
-        var res = await Fetch("authz/ace", "POST", null, null, JsonConvert.SerializeObject(spec));
-
-        if (res.Status != 204)
-        {
-            throw new Exception($"{res.Status}: Can't {spec.Action} ACE");
+            if (res.Status != 204)
+            {
+                throw new Exception($"{res.Status}: Can't {spec.Action} ACE");
+            }
         }
     }
 }

--- a/cs-serviceclient/cs-serviceclient/ServiceClient/Services/ConfigDb.cs
+++ b/cs-serviceclient/cs-serviceclient/ServiceClient/Services/ConfigDb.cs
@@ -1,192 +1,200 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using AMRC.FactoryPlus.ServiceClient.Constants;
 using Cysharp.Threading.Tasks;
 using Newtonsoft.Json;
 
-namespace AMRC.FactoryPlus.ServiceClient.Services;
-
-/// <summary>
-/// The body to be used when PUTing a config
-/// </summary>
-public struct PutConfigBody
+namespace AMRC.FactoryPlus.ServiceClient.Services
 {
-    [JsonProperty("name")]
-    public string Name;
-    [JsonProperty("deleted")]
-    public bool? Deleted;
 
-    public PutConfigBody(string name, bool? deleted = null)
+    /// <summary>
+    /// The body to be used when PUTing a config
+    /// </summary>
+    public struct PutConfigBody
     {
-        Name = name;
-        Deleted = deleted;
-    }
-}
+        [JsonProperty("name")] public string Name;
+        [JsonProperty("deleted")] public bool? Deleted;
 
-public struct ObjectRegistration
-{
-    public Guid Uuid;
-    public Guid Class;
-
-    public ObjectRegistration(Guid uuid, Guid @class)
-    {
-        Uuid = uuid;
-        Class = @class;
-    }
-}
-
-public struct PrinicpalConfig
-{
-    public string GroupId;
-    public string NodeId;
-
-    public PrinicpalConfig(string groupId, string nodeId)
-    {
-        GroupId = groupId;
-        NodeId = nodeId;
-    }
-}
-
-/// <summary>
-/// The ConfigDB service interface
-/// </summary>
-public class ConfigDb : ServiceInterface
-{
-    /// <inheritdoc />
-    public ConfigDb(ServiceClient serviceClient) : base(serviceClient)
-    {
-        ServiceType = ServiceTypes.ConfigDB;
-    }
-    
-    public async UniTask<PrinicpalConfig?> GetConfig(Guid app, Guid obj)
-    {
-        var res = await Fetch($"/v1/app/{app}/object/{obj}");
-
-        if (res.Status == 404)
+        public PutConfigBody(string name, bool? deleted = null)
         {
-            return null;
+            Name = name;
+            Deleted = deleted;
         }
-
-        if (res.Status != 200)
-        {
-            throw new Exception($"{res.Status}: Can't get {app} for {obj}");
-        }
-        
-        return JsonConvert.DeserializeObject<PrinicpalConfig>(res.Content);
     }
 
-    public async UniTask PutConfig(Guid app, Guid obj, string json)
+    public struct ObjectRegistration
     {
-        var res = await Fetch($"/v1/app/{app}/object/{obj}", "PUT", null, null, json);
-        if (res.Status == 204)
-        {
-            return;
-        }
+        public Guid Uuid;
+        public Guid Class;
 
-        throw new Exception($"{res.Status}: Can't set {app} for {obj}");
+        public ObjectRegistration(Guid uuid, Guid @class)
+        {
+            Uuid = uuid;
+            Class = @class;
+        }
     }
 
-    public async UniTask DeleteConfig(Guid app, Guid obj)
+    public struct PrinicpalConfig
     {
-        var res = await Fetch($"/v1/app/{app}/object/{obj}", "DELETE");
-        if (res.Status == 204)
-        {
-            return;
-        }
+        public string GroupId;
+        public string NodeId;
 
-        throw new Exception($"{res.Status}: Can't remove {app} for {obj}");
+        public PrinicpalConfig(string groupId, string nodeId)
+        {
+            GroupId = groupId;
+            NodeId = nodeId;
+        }
     }
 
-    public async UniTask PatchConfig(Guid app, Guid obj, string type, string patch)
+    /// <summary>
+    /// The ConfigDB service interface
+    /// </summary>
+    public class ConfigDb : ServiceInterface
     {
-        if (type != "merge") throw new Exception("Only merge-patch supported");
-        
-        var res = await Fetch($"/v1/app/{app}/object/{obj}", "PATCH", null, null, patch, null, null, "application/merge-patch+json");
-        if (res.Status == 204)
+        /// <inheritdoc />
+        public ConfigDb(ServiceClient serviceClient) : base(serviceClient)
         {
-            return;
+            ServiceType = ServiceTypes.ConfigDB;
         }
 
-        throw new Exception($"{res.Status}: Can't patch {app} for {obj}");
-    }
-
-    public async UniTask<Guid> CreateObject(Guid klass, Guid? objUuidNullable = null, bool exclusive = false)
-    {
-        Guid objUuid = objUuidNullable ?? Guid.Empty;
-        var res = await Fetch("/v1/object", "POST", null, null, JsonConvert.SerializeObject(new ObjectRegistration(objUuid, klass)));
-        if (res.Status == 200 && exclusive)
+        public async UniTask<PrinicpalConfig?> GetConfig(Guid app, Guid obj)
         {
-            throw new Exception($"Exclusive create of {objUuidNullable} failed");
+            var res = await Fetch($"/v1/app/{app}/object/{obj}");
+
+            if (res.Status == 404)
+            {
+                return null;
+            }
+
+            if (res.Status != 200)
+            {
+                throw new Exception($"{res.Status}: Can't get {app} for {obj}");
+            }
+
+            return JsonConvert.DeserializeObject<PrinicpalConfig>(res.Content);
         }
 
-        if (res.Status == 201 || res.Status == 200)
+        public async UniTask PutConfig(Guid app, Guid obj, string json)
         {
-            return JsonConvert.DeserializeObject<ObjectRegistration>(res.Content).Uuid;
+            var res = await Fetch($"/v1/app/{app}/object/{obj}", "PUT", null, null, json);
+            if (res.Status == 204)
+            {
+                return;
+            }
+
+            throw new Exception($"{res.Status}: Can't set {app} for {obj}");
         }
 
-        if (objUuidNullable != null)
+        public async UniTask DeleteConfig(Guid app, Guid obj)
         {
-            throw new Exception($"{res.Status}: Creating {objUuidNullable} failed");
+            var res = await Fetch($"/v1/app/{app}/object/{obj}", "DELETE");
+            if (res.Status == 204)
+            {
+                return;
+            }
+
+            throw new Exception($"{res.Status}: Can't remove {app} for {obj}");
         }
 
-        throw new Exception($"{res.Status}: Creating new {klass} failed");
-    }
-
-    public async UniTask DeleteObject(Guid objUuid)
-    {
-        var res = await Fetch($"/v1/object/{objUuid}", "DELETE");
-        
-        if (res.Status == 204)
+        public async UniTask PatchConfig(Guid app, Guid obj, string type, string patch)
         {
-            return;
+            if (type != "merge") throw new Exception("Only merge-patch supported");
+
+            var res = await Fetch($"/v1/app/{app}/object/{obj}", "PATCH", null, null, patch, null, null,
+                "application/merge-patch+json");
+            if (res.Status == 204)
+            {
+                return;
+            }
+
+            throw new Exception($"{res.Status}: Can't patch {app} for {obj}");
         }
 
-        throw new Exception($"{res.Status}: Deleting {objUuid} failed");
-    }
-
-    public async UniTask<Guid[]?> Search(Guid app, Dictionary<string, object> query, Dictionary<string, string> results, string? klass = "")
-    {
-        var qs = query
-                      .Select(q => new KeyValuePair<string, string>(q.Key, JsonConvert.SerializeObject(q.Value)))
-                      .ToDictionary(pair => pair.Key, pair => pair.Value);
-        var localResults = results
-                           .Select(q => new KeyValuePair<string, string>($"@{q.Key}", q.Value))
-                           .ToDictionary(pair => pair.Key, pair => pair.Value);
-        var queries = qs
-                      .Concat(localResults)
-                      .ToDictionary(pair => pair.Key, pair => pair.Value);
-
-        var response = await ServiceClient.Fetch.Fetch($"/v1/app/{app}{klass ?? ""}/search", "GET", queries, UUIDs.Service[ServiceTypes.ConfigDB]);
-
-        if (response.Status != 200)
+        public async UniTask<Guid> CreateObject(Guid klass, Guid? objUuidNullable = null, bool exclusive = false)
         {
-            Debug.WriteLine($"ConfigDB - Search failed: {response.Status}");
+            Guid objUuid = objUuidNullable ?? Guid.Empty;
+            var res = await Fetch("/v1/object", "POST", null, null,
+                JsonConvert.SerializeObject(new ObjectRegistration(objUuid, klass)));
+            if (res.Status == 200 && exclusive)
+            {
+                throw new Exception($"Exclusive create of {objUuidNullable} failed");
+            }
 
-            return null;
+            if (res.Status == 201 || res.Status == 200)
+            {
+                return JsonConvert.DeserializeObject<ObjectRegistration>(res.Content).Uuid;
+            }
+
+            if (objUuidNullable != null)
+            {
+                throw new Exception($"{res.Status}: Creating {objUuidNullable} failed");
+            }
+
+            throw new Exception($"{res.Status}: Creating new {klass} failed");
         }
 
-        var uuids = JsonConvert.DeserializeObject<Guid[]>(response.Content);
-        return uuids;
-    }
-
-    public async UniTask<Guid> Resolve(Guid app, Dictionary<string, object> query, Dictionary<string, string> results, string? klass)
-    {
-        var uuids = await Search(app, query, new Dictionary<string, string>(), klass);
-
-        if (uuids == null)
+        public async UniTask DeleteObject(Guid objUuid)
         {
-            throw new Exception("Search didn't return an array");
+            var res = await Fetch($"/v1/object/{objUuid}", "DELETE");
+
+            if (res.Status == 204)
+            {
+                return;
+            }
+
+            throw new Exception($"{res.Status}: Deleting {objUuid} failed");
         }
 
-        if (uuids.Length == 0)
+        public async UniTask<Guid[]?> Search(Guid app, Dictionary<string, object> query,
+                                             Dictionary<string, string> results, string? klass = "")
         {
-            throw new Exception($"Search didn't return any results: {app} with {query}");
+            var qs = query
+                     .Select(q => new KeyValuePair<string, string>(q.Key, JsonConvert.SerializeObject(q.Value)))
+                     .ToDictionary(pair => pair.Key, pair => pair.Value);
+            var localResults = results
+                               .Select(q => new KeyValuePair<string, string>($"@{q.Key}", q.Value))
+                               .ToDictionary(pair => pair.Key, pair => pair.Value);
+            var queries = qs
+                          .Concat(localResults)
+                          .ToDictionary(pair => pair.Key, pair => pair.Value);
+
+            var response = await ServiceClient.Fetch.Fetch($"/v1/app/{app}{klass ?? ""}/search", "GET", queries,
+                UUIDs.Service[ServiceTypes.ConfigDB]);
+
+            if (response.Status != 200)
+            {
+                Debug.WriteLine($"ConfigDB - Search failed: {response.Status}");
+
+                return null;
+            }
+
+            var uuids = JsonConvert.DeserializeObject<Guid[]>(response.Content);
+            return uuids;
         }
 
-        if (uuids.Length > 1)
+        public async UniTask<Guid> Resolve(Guid app, Dictionary<string, object> query,
+                                           Dictionary<string, string> results, string? klass)
         {
-            throw new Exception($"Search return more than one result: {app} with {query}");
+            var uuids = await Search(app, query, new Dictionary<string, string>(), klass);
+
+            if (uuids == null)
+            {
+                throw new Exception("Search didn't return an array");
+            }
+
+            if (uuids.Length == 0)
+            {
+                throw new Exception($"Search didn't return any results: {app} with {query}");
+            }
+
+            if (uuids.Length > 1)
+            {
+                throw new Exception($"Search return more than one result: {app} with {query}");
+            }
+
+            return uuids[0];
         }
-        
-        return uuids[0];
     }
 }

--- a/cs-serviceclient/cs-serviceclient/ServiceClient/Services/Directory.cs
+++ b/cs-serviceclient/cs-serviceclient/ServiceClient/Services/Directory.cs
@@ -1,74 +1,79 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using AMRC.FactoryPlus.ServiceClient.Constants;
 using Cysharp.Threading.Tasks;
 using Newtonsoft.Json;
 
-namespace AMRC.FactoryPlus.ServiceClient.Services;
-
-public struct ServiceProvider
+namespace AMRC.FactoryPlus.ServiceClient.Services
 {
-    public Guid? Device;
-    public string Url;
 
-    public ServiceProvider(Guid? device, string url)
+    public struct ServiceProvider
     {
-        Device = device;
-        Url = url;
+        public Guid? Device;
+        public string Url;
+
+        public ServiceProvider(Guid? device, string url)
+        {
+            Device = device;
+            Url = url;
+        }
     }
-}
 
-public struct ServiceProviderList
-{
-    public List<ServiceProvider> List;
-
-    public ServiceProviderList(List<ServiceProvider> list) => List = list;
-}
-
-/// <summary>
-/// The Directory service interface
-/// </summary>
-public class Directory : ServiceInterface
-{
-    /// <inheritdoc />
-    public Directory(ServiceClient serviceClient) : base(serviceClient)
+    public struct ServiceProviderList
     {
-        ServiceType = ServiceTypes.Directory;
+        public List<ServiceProvider> List;
+
+        public ServiceProviderList(List<ServiceProvider> list) => List = list;
     }
-    
+
     /// <summary>
-    /// Gets a list of URLs that point to a service
+    /// The Directory service interface
     /// </summary>
-    /// <param name="service">The service to query</param>
-    /// <returns>List of URLs</returns>
-    public async UniTask<string[]> ServiceUrls(string service)
+    public class Directory : ServiceInterface
     {
-        var res = await Fetch($"/v1/service/{service}");
-
-        if (res.Status == 404)
+        /// <inheritdoc />
+        public Directory(ServiceClient serviceClient) : base(serviceClient)
         {
-            Debug.WriteLine($"{res.Status}: Can't find service {service}");
-            return new string[]{};
+            ServiceType = ServiceTypes.Directory;
         }
 
-        if (res.Status != 200)
+        /// <summary>
+        /// Gets a list of URLs that point to a service
+        /// </summary>
+        /// <param name="service">The service to query</param>
+        /// <returns>List of URLs</returns>
+        public async UniTask<string[]> ServiceUrls(string service)
         {
-            throw new Exception($"{res.Status}: Can't get service records for {service}");
+            var res = await Fetch($"/v1/service/{service}");
+
+            if (res.Status == 404)
+            {
+                Debug.WriteLine($"{res.Status}: Can't find service {service}");
+                return new string[] { };
+            }
+
+            if (res.Status != 200)
+            {
+                throw new Exception($"{res.Status}: Can't get service records for {service}");
+            }
+
+            Debug.WriteLine($"{service} URLs: {res.Content}");
+            var specs = JsonConvert.DeserializeObject<List<ServiceProvider>>(res.Content);
+            return specs.Select(s => s.Url).Where(s => !String.IsNullOrEmpty(s)).ToArray();
         }
 
-        Debug.WriteLine($"{service} URLs: {res.Content}");
-        var specs = JsonConvert.DeserializeObject<List<ServiceProvider>>(res.Content);
-        return specs.Select(s => s.Url).Where(s => !String.IsNullOrEmpty(s)).ToArray();
-    }
-
-    public async void RegisterServiceUrl(string service, string url)
-    {
-        var res = await Fetch($"/v1/service/{service}/advertisment", "PUT", null, null, $"{{\"url\": \"{url}\"}}");
-        
-        if (res.Status != 204)
+        public async void RegisterServiceUrl(string service, string url)
         {
-            throw new Exception($"{res.Status}: Can't register service {service}");
-        }
+            var res = await Fetch($"/v1/service/{service}/advertisment", "PUT", null, null, $"{{\"url\": \"{url}\"}}");
 
-        Debug.WriteLine($"Registered {url} for {service}");
+            if (res.Status != 204)
+            {
+                throw new Exception($"{res.Status}: Can't register service {service}");
+            }
+
+            Debug.WriteLine($"Registered {url} for {service}");
+        }
     }
 }

--- a/cs-serviceclient/cs-serviceclient/ServiceClient/Services/Discovery.cs
+++ b/cs-serviceclient/cs-serviceclient/ServiceClient/Services/Discovery.cs
@@ -1,85 +1,89 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using AMRC.FactoryPlus.ServiceClient.Constants;
 using Cysharp.Threading.Tasks;
 
-namespace AMRC.FactoryPlus.ServiceClient.Services;
-
-/// <summary>
-/// The Discover service interface
-/// </summary>
-public class Discovery : ServiceInterface
+namespace AMRC.FactoryPlus.ServiceClient.Services
 {
-    private readonly Dictionary<Guid, string?> _urls;
 
-    /// <inheritdoc />
-    public Discovery(ServiceClient serviceClient) : base(serviceClient)
+    /// <summary>
+    /// The Discover service interface
+    /// </summary>
+    public class Discovery : ServiceInterface
     {
-        _urls = new Dictionary<Guid, string?>();
-        Dictionary<Guid, string?> presets = new()
-        {
-            {UUIDs.Service[ServiceTypes.Authentication], ServiceClient.AuthnUrl},
-            {UUIDs.Service[ServiceTypes.ConfigDB], ServiceClient.ConfigDbUrl},
-            {UUIDs.Service[ServiceTypes.Directory], ServiceClient.DirectoryUrl},
-            {UUIDs.Service[ServiceTypes.MQTT], ServiceClient.MqttUrl}
-        };
+        private readonly Dictionary<Guid, string?> _urls;
 
-        foreach (var preset in presets)
+        /// <inheritdoc />
+        public Discovery(ServiceClient serviceClient) : base(serviceClient)
         {
-            if (String.IsNullOrEmpty(preset.Value))
+            _urls = new Dictionary<Guid, string?>();
+            Dictionary<Guid, string?> presets = new Dictionary<Guid, string?>()
             {
-                continue;
+                {UUIDs.Service[ServiceTypes.Authentication], ServiceClient.AuthnUrl},
+                {UUIDs.Service[ServiceTypes.ConfigDB], ServiceClient.ConfigDbUrl},
+                {UUIDs.Service[ServiceTypes.Directory], ServiceClient.DirectoryUrl},
+                {UUIDs.Service[ServiceTypes.MQTT], ServiceClient.MqttUrl}
+            };
+
+            foreach (var preset in presets)
+            {
+                if (String.IsNullOrEmpty(preset.Value))
+                {
+                    continue;
+                }
+
+                Debug.WriteLine($"Preset URL for {preset.Key}: {preset.Value}");
+                SetServiceUrl(preset.Key, preset.Value);
+            }
+        }
+
+        /// <summary>
+        /// Gets a list of URLs that point to a service
+        /// </summary>
+        /// <param name="service">The service to query</param>
+        /// <returns>List of URLs</returns>
+        public async UniTask<string[]> FindServiceUrls(string service)
+        {
+            return await ServiceClient.Directory.ServiceUrls(service);
+        }
+
+        /* XXX This interface is deprecated. Services may have multiple
+         * URLs, and we cannot do liveness testing here as we don't know all
+         * the protocols. */
+        /// <summary>
+        /// Gets the first known URL that points to a service
+        /// </summary>
+        /// <param name="service">The service to query</param>
+        /// <returns>The URL</returns>
+        public async UniTask<string?> ServiceUrl(Guid service)
+        {
+            var urls = await ServiceUrls(service);
+            return String.IsNullOrWhiteSpace(urls[0]) ? null : urls[0];
+        }
+
+        private async UniTask<string?[]> ServiceUrls(Guid service)
+        {
+            if (_urls.TryGetValue(service, out var url) && !String.IsNullOrWhiteSpace(url))
+            {
+                Debug.WriteLine($"[{service}]Found {url} preconfigured");
+                return new[] {url};
             }
 
-            Debug.WriteLine($"Preset URL for {preset.Key}: {preset.Value}");
-            SetServiceUrl(preset.Key, preset.Value);
+            var urls = await FindServiceUrls(service.ToString());
+
+            if (urls != null && urls.Length > 0)
+            {
+                Debug.WriteLine($"[{service}] Discover returned {String.Join(", ", urls)}");
+                return urls;
+            }
+
+            return Array.Empty<string>();
         }
-    }
 
-    /// <summary>
-    /// Gets a list of URLs that point to a service
-    /// </summary>
-    /// <param name="service">The service to query</param>
-    /// <returns>List of URLs</returns>
-    public async UniTask<string[]> FindServiceUrls(string service)
-    {
-        return await ServiceClient.Directory.ServiceUrls(service);
-    }
-
-    /* XXX This interface is deprecated. Services may have multiple
-     * URLs, and we cannot do liveness testing here as we don't know all
-     * the protocols. */
-    /// <summary>
-    /// Gets the first known URL that points to a service
-    /// </summary>
-    /// <param name="service">The service to query</param>
-    /// <returns>The URL</returns>
-    public async UniTask<string?> ServiceUrl(Guid service)
-    {
-        var urls = await ServiceUrls(service);
-        return String.IsNullOrWhiteSpace(urls[0]) ? null : urls[0];
-    }
-
-    private async UniTask<string?[]> ServiceUrls(Guid service)
-    {
-        if (_urls.TryGetValue(service, out var url) && !String.IsNullOrWhiteSpace(url))
+        internal void SetServiceUrl(Guid service, string? url)
         {
-            Debug.WriteLine($"[{service}]Found {url} preconfigured");
-            return new[] {url};
+            _urls[service] = url;
         }
-        
-        var urls = await FindServiceUrls(service.ToString());
-
-        if (urls is {Length: > 0})
-        {
-            Debug.WriteLine($"[{service}] Discover returned {String.Join(", ", urls)}");
-            return urls;
-        }
-        
-        return Array.Empty<string>();
-    }
-
-    internal void SetServiceUrl(Guid service, string? url)
-    {
-        _urls[service] = url;
     }
 }

--- a/cs-serviceclient/cs-serviceclient/ServiceClient/Services/Fetch.cs
+++ b/cs-serviceclient/cs-serviceclient/ServiceClient/Services/Fetch.cs
@@ -1,220 +1,243 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Http;
 using System.Security.Authentication;
+using System.Threading;
+using System.Threading.Tasks;
 using Cysharp.Threading.Tasks;
 using Flurl;
 using Flurl.Http;
+using MQTTnet.Internal;
 using Newtonsoft.Json;
 
-namespace AMRC.FactoryPlus.ServiceClient.Services;
-
-public struct TokenStruct
+namespace AMRC.FactoryPlus.ServiceClient.Services
 {
-    public string Token;
-    public string Expiry;
 
-    public TokenStruct(string token, string expiry)
+    public struct TokenStruct
     {
-        Token = token;
-        Expiry = expiry;
-    }
-}
+        public string Token;
+        public string Expiry;
 
-/// <summary>
-/// The Fetch service interface
-/// </summary>
-public class FetchClass : ServiceInterface
-{
-    private readonly Dictionary<string, UniTask<FetchResponse>> _inflight;
-    private readonly Dictionary<string, UniTask<string>> _inflightTokens;
-    private readonly Dictionary<string, string> _tokens;
-    
-    /// <inheritdoc />
-    public FetchClass(ServiceClient serviceClient) : base(serviceClient)
-    {
-        _inflight = new Dictionary<string, UniTask<FetchResponse>>();
-        _inflightTokens = new Dictionary<string, UniTask<string>>();
-        _tokens = new Dictionary<string, string>();
+        public TokenStruct(string token, string expiry)
+        {
+            Token = token;
+            Expiry = expiry;
+        }
     }
 
-    /// <inheritdoc />
-    public override async UniTask<FetchResponse> Fetch(string url, string method = "GET", object? query = null, Guid? service = null, string? body = null, Dictionary<string, string>? headers = null, string? accept = null, string? contentType = null)
+    /// <summary>
+    /// The Fetch service interface
+    /// </summary>
+    public class FetchClass : ServiceInterface
     {
-        var serviceUrl = "";
-        var amendedUrl = url;
-        if (service != null)
+        private readonly Dictionary<string, UniTask<FetchResponse>> _inflight;
+        private readonly Dictionary<string, UniTask<string>> _inflightTokens;
+        private readonly Dictionary<string, string> _tokens;
+
+        /// <inheritdoc />
+        public FetchClass(ServiceClient serviceClient) : base(serviceClient)
         {
-            serviceUrl = await ServiceClient.Discovery.ServiceUrl((Guid)service) ?? "";
-            amendedUrl = serviceUrl.AppendPathSegment(url);
+            _inflight = new Dictionary<string, UniTask<FetchResponse>>();
+            _inflightTokens = new Dictionary<string, UniTask<string>>();
+            _tokens = new Dictionary<string, string>();
         }
 
-        // Don't mess with stateful requests
-        if (!IsIdempotent(method, headers, body))
+        /// <inheritdoc />
+        public override async UniTask<FetchResponse> Fetch(string url, string method = "GET", object? query = null,
+                                                           Guid? service = null, string? body = null,
+                                                           Dictionary<string, string>? headers = null,
+                                                           string? accept = null, string? contentType = null)
         {
-            return await DoFetch(amendedUrl, serviceUrl, method, query, service, body, headers, accept, contentType);
-        }
-
-        // If there is already a request to this URL, we can piggyback on it
-        if (_inflight.TryGetValue(amendedUrl, out var currentInflight))
-        {
-            return await currentInflight;
-        }
-
-        var responseTask = DoFetch(amendedUrl, serviceUrl, method);
-        // Store the task for other requests to use
-        _inflight[amendedUrl] = responseTask;
-
-        FetchResponse response;
-        try
-        {
-            response = await responseTask;
-        }
-        finally
-        {
-            // Make sure to clear the inflight task whether it is a success or failure
-             _inflight.Remove(amendedUrl);
-        }
-        
-        return response;
-    }
-
-    private async UniTask<FetchResponse> DoFetch(string url, string serviceUrl, string method, object? query = null, Guid? service = null, string? body = null, Dictionary<string, string>? headers = null, string? accept = null, string? contentType = null)
-    {
-        var token = "";
-
-        async Task<FetchResponse> tryFetch()
-        {
-            token = await ServiceToken(serviceUrl, token);
-            if (String.IsNullOrEmpty(token))
+            var serviceUrl = "";
+            var amendedUrl = url;
+            if (service != null)
             {
-                return new FetchResponse(401, "");
+                serviceUrl = await ServiceClient.Discovery.ServiceUrl((Guid) service) ?? "";
+                amendedUrl = serviceUrl.AppendPathSegment(url);
             }
 
-            var localHeaders = new Dictionary<string, string>(headers ?? new Dictionary<string, string>()) {["Accept"] = accept ?? "application/json"};
-            if (!String.IsNullOrWhiteSpace(body))
+            // Don't mess with stateful requests
+            if (!IsIdempotent(method, headers, body))
             {
-                localHeaders["Content-Type"] = contentType ?? "application/json";
+                return await DoFetch(amendedUrl, serviceUrl, method, query, service, body, headers, accept,
+                    contentType);
             }
 
-            localHeaders = AddAuthHeaders(headers, "Bearer", token);
-
-            var response = await url.WithHeaders(localHeaders)
-                                    .SetQueryParams(query)
-                                    .SendAsync(new HttpMethod(method), new StringContent(body ?? ""), CancellationToken.None)
-                                    .WaitAsync(CancellationToken.None);
-
-            return new FetchResponse(response.StatusCode, await response.GetStringAsync());
-        }
-
-        var res = await tryFetch();
-        if (res.Status == 401)
-        {
-            res = await tryFetch();
-        }
-        
-        return res;
-    }
-
-    private async UniTask<string> ServiceToken(string serviceUrl, string? badToken)
-    {
-        if (!_tokens.TryGetValue(serviceUrl, out var token))
-        {
-            if (_inflightTokens.TryGetValue(serviceUrl, out var inflightToken))
+            // If there is already a request to this URL, we can piggyback on it
+            if (_inflight.TryGetValue(amendedUrl, out var currentInflight))
             {
-                var resolvedToken = await inflightToken;
-                Debug.WriteLine($"Using token {resolvedToken} for {serviceUrl}");
-                return resolvedToken;
+                return await currentInflight;
             }
+
+            var responseTask = DoFetch(amendedUrl, serviceUrl, method);
+            // Store the task for other requests to use
+            _inflight[amendedUrl] = responseTask;
+
+            FetchResponse response;
+            try
+            {
+                response = await responseTask;
+            }
+            finally
+            {
+                // Make sure to clear the inflight task whether it is a success or failure
+                _inflight.Remove(amendedUrl);
+            }
+
+            return response;
         }
 
-        var isBad = !String.IsNullOrEmpty(badToken) && token == badToken;
-        if (!String.IsNullOrEmpty(token) && !isBad)
+        private async UniTask<FetchResponse> DoFetch(string url, string serviceUrl, string method, object? query = null,
+                                                     Guid? service = null, string? body = null,
+                                                     Dictionary<string, string>? headers = null, string? accept = null,
+                                                     string? contentType = null)
         {
+            var token = "";
+
+            async Task<FetchResponse> tryFetch()
+            {
+                token = await ServiceToken(serviceUrl, token);
+                if (String.IsNullOrEmpty(token))
+                {
+                    return new FetchResponse(401, "");
+                }
+
+                var localHeaders =
+                    new Dictionary<string, string>(headers ?? new Dictionary<string, string>())
+                    {
+                        ["Accept"] = accept ?? "application/json"
+                    };
+                if (!String.IsNullOrWhiteSpace(body))
+                {
+                    localHeaders["Content-Type"] = contentType ?? "application/json";
+                }
+
+                localHeaders = AddAuthHeaders(headers, "Bearer", token);
+
+                var response = await url.WithHeaders(localHeaders)
+                                        .SetQueryParams(query)
+                                        .SendAsync(new HttpMethod(method), new StringContent(body ?? ""),
+                                            CancellationToken.None)
+                                        .AsUniTask();
+
+                return new FetchResponse(response.StatusCode, await response.GetStringAsync());
+            }
+
+            var res = await tryFetch();
+            if (res.Status == 401)
+            {
+                res = await tryFetch();
+            }
+
+            return res;
+        }
+
+        private async UniTask<string> ServiceToken(string serviceUrl, string? badToken)
+        {
+            if (!_tokens.TryGetValue(serviceUrl, out var token))
+            {
+                if (_inflightTokens.TryGetValue(serviceUrl, out var inflightToken))
+                {
+                    var resolvedToken = await inflightToken;
+                    Debug.WriteLine($"Using token {resolvedToken} for {serviceUrl}");
+                    return resolvedToken;
+                }
+            }
+
+            var isBad = !String.IsNullOrEmpty(badToken) && token == badToken;
+            if (!String.IsNullOrEmpty(token) && !isBad)
+            {
+                return token;
+            }
+
+            var tokenRequest = FetchToken(serviceUrl);
+            _inflightTokens[serviceUrl] = tokenRequest;
+            try
+            {
+                token = await tokenRequest;
+                Debug.WriteLine($"Using token {token} for {serviceUrl}");
+            }
+            finally
+            {
+                _inflightTokens.Remove(serviceUrl);
+            }
+
             return token;
         }
 
-        var tokenRequest = FetchToken(serviceUrl);
-        _inflightTokens[serviceUrl] = tokenRequest;
-        try
+        private async UniTask<string> FetchToken(string serviceUrl)
         {
-            token = await tokenRequest;
-            Debug.WriteLine($"Using token {token} for {serviceUrl}");
-        }
-        finally
-        {
-            _inflightTokens.Remove(serviceUrl);
-        }
+            var tokenUrl = serviceUrl.AppendPathSegment("token");
+            var res = await GssFetch(tokenUrl);
 
-        return token;
-    }
-
-    private async UniTask<string> FetchToken(string serviceUrl)
-    {
-        var tokenUrl = serviceUrl.AppendPathSegment("token");
-        var res = await GssFetch(tokenUrl);
-
-        if (res.Status != 200)
-        {
-            throw new Exception($"Token fetch failed for {serviceUrl}");
-        }
-
-        var token = JsonConvert.DeserializeObject<TokenStruct>(res.Content);
-        _tokens[serviceUrl] = token.Token;
-        return token.Token;
-    }
-
-    private async UniTask<FetchResponse> GssFetch(string tokenUrl)
-    {
-        if (!String.IsNullOrWhiteSpace(ServiceClient.ServiceUsername) && !String.IsNullOrWhiteSpace(ServiceClient.ServicePassword))
-        {
-            // Use basic auth
-            var authBytes = System.Text.Encoding.UTF8.GetBytes($"{ServiceClient.ServiceUsername}:{ServiceClient.ServicePassword}");
-            var authString = Convert.ToBase64String(authBytes);
-            var headers = AddAuthHeaders(null, "Basic", authString);
-            try
+            if (res.Status != 200)
             {
-                var response = await tokenUrl.WithTimeout(5).WithHeaders(headers)
-                                             .PostAsync(null, CancellationToken.None).WaitAsync(CancellationToken.None);
-                return new FetchResponse(response.StatusCode, await response.GetStringAsync());
+                throw new Exception($"Token fetch failed for {serviceUrl}");
             }
-            catch (FlurlHttpException e)
+
+            var token = JsonConvert.DeserializeObject<TokenStruct>(res.Content);
+            _tokens[serviceUrl] = token.Token;
+            return token.Token;
+        }
+
+        private async UniTask<FetchResponse> GssFetch(string tokenUrl)
+        {
+            if (!String.IsNullOrWhiteSpace(ServiceClient.ServiceUsername) &&
+                !String.IsNullOrWhiteSpace(ServiceClient.ServicePassword))
             {
-                Debug.WriteLine(e);
-                if (e.StatusCode is 401)
+                // Use basic auth
+                var authBytes =
+                    System.Text.Encoding.UTF8.GetBytes(
+                        $"{ServiceClient.ServiceUsername}:{ServiceClient.ServicePassword}");
+                var authString = Convert.ToBase64String(authBytes);
+                var headers = AddAuthHeaders(null, "Basic", authString);
+                try
                 {
-                    throw new AuthenticationException(
-                        "Unable to authenticate with Basic auth, are credentials correct?", e);
+                    var response = await tokenUrl.WithTimeout(5).WithHeaders(headers)
+                                                 .PostAsync(null, CancellationToken.None).AsUniTask();
+                    return new FetchResponse(response.StatusCode, await response.GetStringAsync());
                 }
+                catch (FlurlHttpException e)
+                {
+                    Debug.WriteLine(e);
+                    if (e.StatusCode is 401)
+                    {
+                        throw new AuthenticationException(
+                            "Unable to authenticate with Basic auth, are credentials correct?", e);
+                    }
 
-                throw;
+                    throw;
+                }
             }
+
+            throw new Exception("Only Basic auth supported at this time. Ensure config has username and password");
         }
 
-        throw new Exception("Only Basic auth supported at this time. Ensure config has username and password");
-    }
-
-    private Dictionary<string, string> AddAuthHeaders(Dictionary<string, string>? existingHeaders, string scheme,
-                                                      string credentials)
-    {
-        var localHeaders = existingHeaders ?? new Dictionary<string, string>();
-        localHeaders["Authorization"] = $"{scheme} {credentials}";
-        return localHeaders;
-    }
-
-    private static bool IsIdempotent(string method, Dictionary<string, string>? headers, string? body)
-    {
-        // Only GET requests can be idempotent
-        if (method != "GET")
+        private Dictionary<string, string> AddAuthHeaders(Dictionary<string, string>? existingHeaders, string scheme,
+                                                          string credentials)
         {
-            return false;
+            var localHeaders = existingHeaders ?? new Dictionary<string, string>();
+            localHeaders["Authorization"] = $"{scheme} {credentials}";
+            return localHeaders;
         }
 
-        // Can't be idempotent with headers
-        if (headers is {Count: > 0})
+        private static bool IsIdempotent(string method, Dictionary<string, string>? headers, string? body)
         {
-            return false;
-        }
+            // Only GET requests can be idempotent
+            if (method != "GET")
+            {
+                return false;
+            }
 
-        // Can only be idempotent with an empty body
-        return String.IsNullOrWhiteSpace(body);
+            // Can't be idempotent with headers
+            if (headers != null && headers.Count > 0)
+            {
+                return false;
+            }
+
+            // Can only be idempotent with an empty body
+            return String.IsNullOrWhiteSpace(body);
+        }
     }
 }

--- a/cs-serviceclient/cs-serviceclient/ServiceClient/Services/MQTTInterface.cs
+++ b/cs-serviceclient/cs-serviceclient/ServiceClient/Services/MQTTInterface.cs
@@ -1,93 +1,100 @@
-﻿using AMRC.FactoryPlus.ServiceClient.Constants;
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AMRC.FactoryPlus.ServiceClient.Constants;
 using Com.Cirruslink.Sparkplug.Protobuf;
 using Cysharp.Threading.Tasks;
 using MQTTnet;
 using MQTTnet.Client;
 
-namespace AMRC.FactoryPlus.ServiceClient.Services;
-
-/// <summary>
-/// The MQTT service interface
-/// </summary>
-public class MqttInterface : ServiceInterface
+namespace AMRC.FactoryPlus.ServiceClient.Services
 {
-    /// <summary>
-    /// The type of handler method required when an MQTT message is received.
-    /// </summary>
-    /// <param name="mqttClient">The MqttClient that the message came to</param>
-    /// <param name="payload">The Payload of the message, decided from Sparkplug protobufs for consumption</param>
-    /// <param name="message">The raw MQTT message, which will likely be encoded in protobufs</param>
-    public delegate void MessageReceivedHandler(IMqttClient mqttClient, Payload payload, MqttApplicationMessage message);
-    
-    /// <summary>
-    /// Event fired when a message is received a connected MqttClient.
-    /// This can be handled externally, in user-code, but this helper abstracts away some concepts.
-    /// The Google.Protobuf library and Sparkplug proto classes are used to decode the incoming Payload.
-    /// This makes it easier to consume the result (i.e. the Metrics, or other data).
-    /// The raw MqttApplicationMessage is provided for user-code to interact with if required.
-    /// </summary>
-    public event MessageReceivedHandler OnMessageReceived;
-
-    
-    /// <inheritdoc />
-    public MqttInterface(ServiceClient serviceClient) : base(serviceClient)
-    {
-        ServiceType = ServiceTypes.MQTT;
-    }
 
     /// <summary>
-    /// Sets up an MQTTClient connection
+    /// The MQTT service interface
     /// </summary>
-    /// <returns>A connected instance of an MQTTClient</returns>
-    /// <exception cref="Exception"></exception>
-    public async UniTask<IMqttClient> GetMqttClient(string? hostUrl = "")
+    public class MqttInterface : ServiceInterface
     {
-        var url = hostUrl ?? "";
-        if (String.IsNullOrEmpty(url))
+        /// <summary>
+        /// The type of handler method required when an MQTT message is received.
+        /// </summary>
+        /// <param name="mqttClient">The MqttClient that the message came to</param>
+        /// <param name="payload">The Payload of the message, decided from Sparkplug protobufs for consumption</param>
+        /// <param name="message">The raw MQTT message, which will likely be encoded in protobufs</param>
+        public delegate void MessageReceivedHandler(IMqttClient mqttClient, Payload payload,
+                                                    MqttApplicationMessage message);
+
+        /// <summary>
+        /// Event fired when a message is received a connected MqttClient.
+        /// This can be handled externally, in user-code, but this helper abstracts away some concepts.
+        /// The Google.Protobuf library and Sparkplug proto classes are used to decode the incoming Payload.
+        /// This makes it easier to consume the result (i.e. the Metrics, or other data).
+        /// The raw MqttApplicationMessage is provided for user-code to interact with if required.
+        /// </summary>
+        public event MessageReceivedHandler OnMessageReceived;
+
+
+        /// <inheritdoc />
+        public MqttInterface(ServiceClient serviceClient) : base(serviceClient)
         {
-            url = await ServiceClient.Discovery.ServiceUrl(UUIDs.Service[ServiceTypes.MQTT]);
+            ServiceType = ServiceTypes.MQTT;
         }
 
-        if (String.IsNullOrEmpty(url))
+        /// <summary>
+        /// Sets up an MQTTClient connection
+        /// </summary>
+        /// <returns>A connected instance of an MQTTClient</returns>
+        /// <exception cref="Exception"></exception>
+        public async UniTask<IMqttClient> GetMqttClient(string? hostUrl = "")
         {
-            throw new Exception("No host provided and no url could be found");
-        }
-        
-        if (!String.IsNullOrEmpty(ServiceClient.ServiceUsername) &&
-            !String.IsNullOrEmpty(ServiceClient.ServicePassword))
-        {
-            return await BasicClient(url, ServiceClient.ServiceUsername, ServiceClient.ServicePassword);
+            var url = hostUrl ?? "";
+            if (String.IsNullOrEmpty(url))
+            {
+                url = await ServiceClient.Discovery.ServiceUrl(UUIDs.Service[ServiceTypes.MQTT]);
+            }
+
+            if (String.IsNullOrEmpty(url))
+            {
+                throw new Exception("No host provided and no url could be found");
+            }
+
+            if (!String.IsNullOrEmpty(ServiceClient.ServiceUsername) &&
+                !String.IsNullOrEmpty(ServiceClient.ServicePassword))
+            {
+                return await BasicClient(url, ServiceClient.ServiceUsername, ServiceClient.ServicePassword);
+            }
+
+            throw new Exception("No username or password available");
         }
 
-        throw new Exception("No username or password available");
-    }
+        private async UniTask<IMqttClient> BasicClient(string url, string username, string password)
+        {
+            var mqttFactory = new MqttFactory();
+            var mqttClient = mqttFactory.CreateMqttClient();
 
-    private async UniTask<IMqttClient> BasicClient(string url, string username, string password)
-    {
-        var mqttFactory = new MqttFactory();
-        var mqttClient = mqttFactory.CreateMqttClient();
-        
-        var hostUri = new Uri(url);
-        var mqttClientOptions = new MqttClientOptionsBuilder()
-                                // TODO: .WithClientId()
-                                .WithTcpServer(hostUri.Host, hostUri.Port > 0 ? hostUri.Port : null)
-                                .WithCredentials(username, password)
-                                .WithTls()
-                                // TODO: .WithCleanStart()
-                                .Build();
-        
-        mqttClient.ApplicationMessageReceivedAsync += e =>
-        {
-            var payload = Payload.Parser.ParseFrom(e.ApplicationMessage.PayloadSegment);
-            OnMessageReceived.Invoke(mqttClient, payload, e.ApplicationMessage);
-            return Task.CompletedTask;
-        };
-        
-        var response = await mqttClient.ConnectAsync(mqttClientOptions, CancellationToken.None);
-        if (response == null || response.ResultCode != MqttClientConnectResultCode.Success)
-        {
-            throw new Exception($"Failed to connect to MQTT server {response?.ResultCode.ToString()}");
+            var hostUri = new Uri(url);
+            var mqttClientOptions = new MqttClientOptionsBuilder()
+                                    // TODO: .WithClientId()
+                                    .WithTcpServer(hostUri.Host, hostUri.Port > 0 ? hostUri.Port : (int?) null)
+                                    .WithCredentials(username, password)
+                                    .WithTls()
+                                    // TODO: .WithCleanStart()
+                                    .Build();
+
+            mqttClient.ApplicationMessageReceivedAsync += e =>
+            {
+                var payload = Payload.Parser.ParseFrom(e.ApplicationMessage.PayloadSegment);
+                OnMessageReceived.Invoke(mqttClient, payload, e.ApplicationMessage);
+                return Task.CompletedTask;
+            };
+
+            var response = await mqttClient.ConnectAsync(mqttClientOptions, CancellationToken.None);
+            if (response == null || response.ResultCode != MqttClientConnectResultCode.Success)
+            {
+                throw new Exception($"Failed to connect to MQTT server {response?.ResultCode.ToString()}");
+            }
+
+            return mqttClient;
         }
-        return mqttClient;
     }
 }

--- a/cs-serviceclient/cs-serviceclient/ServiceClient/Services/ServiceInterface.cs
+++ b/cs-serviceclient/cs-serviceclient/ServiceClient/Services/ServiceInterface.cs
@@ -1,114 +1,130 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using AMRC.FactoryPlus.ServiceClient.Constants;
 using Cysharp.Threading.Tasks;
 using Newtonsoft.Json;
 
-namespace AMRC.FactoryPlus.ServiceClient.Services;
-
-/// <summary>
-/// The response expected from a Fetch request
-/// </summary>
-public struct FetchResponse
+namespace AMRC.FactoryPlus.ServiceClient.Services
 {
+
     /// <summary>
-    /// Creates a FetchResponse object
+    /// The response expected from a Fetch request
     /// </summary>
-    /// <param name="status">The status code of the request</param>
-    /// <param name="content">The content of the response</param>
-    public FetchResponse(int status, string content)
+    public struct FetchResponse
     {
-        Status = status;
-        Content = content;
+        /// <summary>
+        /// Creates a FetchResponse object
+        /// </summary>
+        /// <param name="status">The status code of the request</param>
+        /// <param name="content">The content of the response</param>
+        public FetchResponse(int status, string content)
+        {
+            Status = status;
+            Content = content;
+        }
+
+        /// <summary>
+        /// The status code returned by the request
+        /// </summary>
+        public int Status { get; }
+
+        /// <summary>
+        /// The content returned in the response
+        /// </summary>
+        public string Content { get; }
     }
-    
-    /// <summary>
-    /// The status code returned by the request
-    /// </summary>
-    public int Status { get; }
-    /// <summary>
-    /// The content returned in the response
-    /// </summary>
-    public string Content { get; }
-}
 
-public struct PingResponse
-{
-    public readonly string Version;
-
-    public PingResponse(string version) => Version = version;
-}
-
-/// <summary>
-/// A base class for the different services within the stack
-/// </summary>
-public class ServiceInterface
-{
-    /// <summary>
-    /// A reference to the ServiceClient that has been created
-    /// </summary>
-    internal readonly ServiceClient ServiceClient;
-    /// <summary>
-    /// The ServiceType that this service is
-    /// </summary>
-    internal ServiceTypes ServiceType;
-
-    private int _recursionCount = 0;
-    
-    /// <summary>
-    /// Creates a ServiceInterface object
-    /// </summary>
-    /// <param name="serviceClient">The ServiceClient that this interface will talk to</param>
-    public ServiceInterface(ServiceClient serviceClient)
+    public struct PingResponse
     {
-        ServiceClient = serviceClient;
+        public readonly string Version;
+
+        public PingResponse(string version) => Version = version;
     }
 
     /// <summary>
-    /// Fetch a resource
+    /// A base class for the different services within the stack
     /// </summary>
-    /// <param name="url">The URL to request</param>
-    /// <param name="method">The method to use for the request</param>
-    /// <param name="query">The query parameters to use</param>
-    /// <param name="service">The service to be queried</param>
-    /// <param name="body">The body of the request</param>
-    /// <param name="headers">The headers of the request</param>
-    /// <param name="accept">The format to accept back</param>
-    /// <param name="contentType">The type of content being sent</param>
-    /// <returns>A FetchResponse object</returns>
-    public virtual async UniTask<FetchResponse> Fetch(string url, string method = "GET", object? query = null, Guid? service = null, string? body = null, Dictionary<string, string>? headers = null, string? accept = null, string? contentType = null)
+    public class ServiceInterface
     {
-        var localHeaders = new Dictionary<string, string>(headers ?? new Dictionary<string, string>()) {["Accept"] = accept ?? "application/json"};
-        if (!String.IsNullOrWhiteSpace(body))
+        /// <summary>
+        /// A reference to the ServiceClient that has been created
+        /// </summary>
+        internal readonly ServiceClient ServiceClient;
+
+        /// <summary>
+        /// The ServiceType that this service is
+        /// </summary>
+        internal ServiceTypes ServiceType;
+
+        private int _recursionCount = 0;
+
+        /// <summary>
+        /// Creates a ServiceInterface object
+        /// </summary>
+        /// <param name="serviceClient">The ServiceClient that this interface will talk to</param>
+        public ServiceInterface(ServiceClient serviceClient)
         {
-            localHeaders["Content-Type"] = contentType ?? "application/json";
-        }
-        
-        Debug.Assert(!String.IsNullOrWhiteSpace(ServiceClient.DirectoryUrl), "The provided DirectoryUrl is empty, which is unlikely to work.");
-
-        if (_recursionCount > 6)
-        {
-            throw new Exception("Fetch recursion detected, unable to lookup the required service URLs. Have you provided a working Directory URL?");
-        }
-
-        _recursionCount++;
-        var res = await ServiceClient.Fetch.Fetch(url, method, query, UUIDs.Service[ServiceType], body, localHeaders, accept, contentType);
-        _recursionCount = 0;
-        return new FetchResponse(res.Status, res.Content);
-    }
-
-    /// <summary>
-    /// Attempts to ping the stack
-    /// </summary>
-    /// <returns>A string of information</returns>
-    public async UniTask<PingResponse?> Ping()
-    {
-        var response = await Fetch("/ping");
-
-        if (response.Status != 200)
-        {
-            return null;
+            ServiceClient = serviceClient;
         }
 
-        return JsonConvert.DeserializeObject<PingResponse>(response.Content);
+        /// <summary>
+        /// Fetch a resource
+        /// </summary>
+        /// <param name="url">The URL to request</param>
+        /// <param name="method">The method to use for the request</param>
+        /// <param name="query">The query parameters to use</param>
+        /// <param name="service">The service to be queried</param>
+        /// <param name="body">The body of the request</param>
+        /// <param name="headers">The headers of the request</param>
+        /// <param name="accept">The format to accept back</param>
+        /// <param name="contentType">The type of content being sent</param>
+        /// <returns>A FetchResponse object</returns>
+        public virtual async UniTask<FetchResponse> Fetch(string url, string method = "GET", object? query = null,
+                                                          Guid? service = null, string? body = null,
+                                                          Dictionary<string, string>? headers = null,
+                                                          string? accept = null, string? contentType = null)
+        {
+            var localHeaders =
+                new Dictionary<string, string>(headers ?? new Dictionary<string, string>())
+                {
+                    ["Accept"] = accept ?? "application/json"
+                };
+            if (!String.IsNullOrWhiteSpace(body))
+            {
+                localHeaders["Content-Type"] = contentType ?? "application/json";
+            }
+
+            Debug.Assert(!String.IsNullOrWhiteSpace(ServiceClient.DirectoryUrl),
+                "The provided DirectoryUrl is empty, which is unlikely to work.");
+
+            if (_recursionCount > 6)
+            {
+                throw new Exception(
+                    "Fetch recursion detected, unable to lookup the required service URLs. Have you provided a working Directory URL?");
+            }
+
+            _recursionCount++;
+            var res = await ServiceClient.Fetch.Fetch(url, method, query, UUIDs.Service[ServiceType], body,
+                localHeaders, accept, contentType);
+            _recursionCount = 0;
+            return new FetchResponse(res.Status, res.Content);
+        }
+
+        /// <summary>
+        /// Attempts to ping the stack
+        /// </summary>
+        /// <returns>A string of information</returns>
+        public async UniTask<PingResponse?> Ping()
+        {
+            var response = await Fetch("/ping");
+
+            if (response.Status != 200)
+            {
+                return null;
+            }
+
+            return JsonConvert.DeserializeObject<PingResponse>(response.Content);
+        }
     }
 }

--- a/cs-serviceclient/cs-serviceclient/cs-serviceclient.csproj
+++ b/cs-serviceclient/cs-serviceclient/cs-serviceclient.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>AMRC.FactoryPlus</RootNamespace>
-        <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <LangVersion>8</LangVersion>
+        <TargetFrameworks>net481;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
On of the major use cases for this library is for Unity development. We overlooked the actual capabilities of the Unity platform, as it doesn't _yet_ support .NET 6. The library now targets .NET 4.8.1, and the output DLL seems to work in Unity.

To support this, the code needed refactoring since it utilised a lot of C#9 and 10 features that aren't supported in .NET 4.8.1.

#### How to test:

1. Might need the .NET 4.8.1 SDK: https://dotnet.microsoft.com/en-us/download/dotnet-framework/net481
2. Open the library in Rider
3. Clean the solution and then rebuild
4. Notice the /bin/Debug folder now has 4.8.1 and 6.0
5. Run the sample app and notice that it still functions